### PR TITLE
Add support for sandbox test environment

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -12,7 +12,7 @@ To see how to install the SDK go to the [installation section of the SDK](../REA
 
 start the client via php in your desired shell
 ```sh
-php ./SampleCli.php -e (nonlive|live) -u YourUserName -p YourPassword product
+php ./SampleCli.php -e (sandbox|live) -u YourUserName -p YourPassword product
 ```
 
 ## Help
@@ -37,7 +37,7 @@ OPTIONS:
    -p <password>,         password for authentication                          
    --password <password>                                                       
 
-   -e <environment>,      environment: live or nonlive                         
+   -e <environment>,      environment: live or sandbox                         
    --environment                                                               
    <environment>                                                               
 

--- a/samples/SampleCli.php
+++ b/samples/SampleCli.php
@@ -29,7 +29,7 @@ class SampleCli extends PSR3CLI
         $options->registerOption('user', 'username for authentication', 'u', 'user');
         $options->registerOption('password', 'password for authentication', 'p', 'password');
 
-        $options->registerOption('environment', 'environment: live or nonlive', 'e', 'environment');
+        $options->registerOption('environment', 'environment: live or sandbox', 'e', 'environment');
 
         $options->registerCommand('product', 'list all products');
         $options->registerOption('sku', 'filter for specific sku', 's', 'sku', 'product');
@@ -70,8 +70,8 @@ class SampleCli extends PSR3CLI
             case 'live':
                 $configuration = Configuration::forLive($options->getOpt('user'), $options->getOpt('password'));
                 break;
-            case 'nonlive':
-                $configuration = Configuration::forNonlive($options->getOpt('user'), $options->getOpt('password'));
+            case 'sandbox':
+                $configuration = Configuration::forSandbox($options->getOpt('user'), $options->getOpt('password'));
                 break;
             default:
                 $this->error("Invalid environment");

--- a/src/Client/Configuration.php
+++ b/src/Client/Configuration.php
@@ -62,14 +62,14 @@ class Configuration
         $this->httpTimeout         = $httpTimeout;
     }
 
-    public static function forNonlive(string $accessTokenUsername, string $accessTokenPassword): Configuration
+    public static function forSandbox(string $accessTokenUsername, string $accessTokenPassword): Configuration
     {
         return new Configuration(
             $accessTokenUsername,
             $accessTokenPassword,
-            "https://nonlive.api.otto.market/v1/token",
+            "https://sandbox.api.otto.market/v1/token",
             "token-otto-api",
-            "https://nonlive.api.otto.market",
+            "https://sandbox.api.otto.market",
             "marketplace-php-sdk",
             60
         );

--- a/tests/Client/PartnerProductClientTest.php
+++ b/tests/Client/PartnerProductClientTest.php
@@ -21,7 +21,7 @@ class PartnerProductClientTest extends TestCase
     public function setUp(): void
     {
         $this->stub = $this->createStub(Oauth2ApiAccessor::class);
-        $configuration = Configuration::forNonlive("user", "password");
+        $configuration = Configuration::forSandbox("user", "password");
         $logger = new Logger('name');
         $this->client = new PartnerProductClient($configuration, $logger, $this->stub);
     }

--- a/tests/Client/PartnerProductUploadTest.php
+++ b/tests/Client/PartnerProductUploadTest.php
@@ -9,7 +9,6 @@ use Monolog\Logger;
 use Otto\Market\Client\Configuration;
 use Otto\Market\Client\Oauth2\Oauth2ApiAccessor;
 use Otto\Market\Client\PartnerProductClient;
-use Otto\Market\Products\Model\ProductProcessProgress;
 use Otto\Market\Products\Model\ProductVariation;
 use Otto\Market\Products\ObjectSerializer;
 use PHPUnit\Framework\TestCase;

--- a/tests/Client/PartnerProductUploadTest.php
+++ b/tests/Client/PartnerProductUploadTest.php
@@ -22,7 +22,7 @@ class PartnerProductUploadTest extends TestCase
     public function setUp(): void
     {
         $this->stub = $this->createStub(Oauth2ApiAccessor::class);
-        $configuration = Configuration::forNonlive("user", "password");
+        $configuration = Configuration::forSandbox("user", "password");
         $logger = new Logger('name');
         $this->client = new PartnerProductClient($configuration, $logger, $this->stub);
     }

--- a/tests/Client/PartnerShipmentClientTest.php
+++ b/tests/Client/PartnerShipmentClientTest.php
@@ -5,22 +5,16 @@ declare(strict_types=1);
 namespace Otto\Market\Test\Client;
 
 use PHPUnit\Framework\TestCase;
-use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Exception\ClientException;
-use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\ServerException;
 use Otto\Market\Client\PartnerShipmentClient;
 use Otto\Market\Client\Oauth2\Oauth2ApiAccessor;
 use Otto\Market\Client\Configuration;
 use Otto\Market\Shipments\Model\CreateShipmentRequest;
 use Otto\Market\Shipments\Model\PositionItem;
 use Monolog\Logger;
-use Monolog\Handler\StreamHandler;
 
 require_once 'ShipmentJsonResponses.php';
 

--- a/tests/Client/PartnerShipmentClientTest.php
+++ b/tests/Client/PartnerShipmentClientTest.php
@@ -37,7 +37,7 @@ final class PartnerShipmentClientTest extends TestCase
     public function setUp(): void
     {
         $this->stub    = $this->createStub(Oauth2ApiAccessor::class);
-        $configuration = Configuration::forNonlive("user", "password");
+        $configuration = Configuration::forSandbox("user", "password");
         $logger        = new Logger('name');
         $this->client  = new PartnerShipmentClient($configuration, $logger, $this->stub);
     }


### PR DESCRIPTION
Closes #8 

This pr adds support for the sandbox testing environment.
See the [Api docs](https://api.otto.market/docs#section/Sandbox) for support and usage.